### PR TITLE
fixing typo for the source field

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ EXAMPLE
 
 ```hcl
 module "dcos-ansible-bridge" {
-  source  = "dcos-terraform/dcos-ansible-bridge/local_file"
+  source  = "dcos-terraform/dcos-ansible-bridge/localfile"
   version = "~> 0.1"
 
   bootstrap_ip         = "${module.dcos-infrastructure.bootstrap.public_ip}"

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@
  *
  *```hcl
  * module "dcos-ansible-bridge" {
- *   source  = "dcos-terraform/dcos-ansible-bridge/local_file"
+ *   source  = "dcos-terraform/dcos-ansible-bridge/localfile"
  *   version = "~> 0.1"
  *
  *   bootstrap_ip         = "${module.dcos-infrastructure.bootstrap.public_ip}"


### PR DESCRIPTION
Currently the example provided needed an update to work as it had a typo in the source field.